### PR TITLE
[CI] Cleanup GH Action caches of a branch after PR closed

### DIFF
--- a/.github/workflows/cleanup_caches.yaml
+++ b/.github/workflows/cleanup_caches.yaml
@@ -1,0 +1,29 @@
+name: Cleanup Branch Caches
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
 env:
   home: /home/runner
   build: 'true'


### PR DESCRIPTION
- Cleanup GH Action caches of a branch after PR closed.
- Run test Action when merging to main to keep the caches of the main branch updated.