### PR TITLE
[FIX] Fix parsing

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -13,32 +13,33 @@
 #ifndef DEFINES_H
 # define DEFINES_H
 
+# include "libft.h"
 # include <stdio.h>
 # include <stdbool.h>
 # include <math.h>
-# include "libft.h"
 
 /* Error Codes */
 # define SUCCESS			0
 # define ERR_ARGC			1
 # define ERR_INIT			2
 
-# define SPHERE_ARG_NUM		3
-# define PLANE_ARG_NUM		3
-# define CYLINDER_ARG_NUM	5
+/* Error Messages */
+# define INVALID_FILE_FMT		"Invalid file format."
+# define INVALID_IDENTIFIER		"Invalid identifier."
+# define INVALID_NUM_ARG		"Invalid number of arguments."
+# define INVALID_AMB_FMT		"Invalid ambient light format."
+# define INVALID_CAM_FMT		"Invalid camera format."
+# define INVALID_LIG_FMT		"Invalid light format."
+# define INVALID_SPH_FMT		"Invalid sphere format."
+# define INVALID_PLA_FMT		"Invalid plane format."
+# define INVALID_CYL_FMT		"Invalid cylinder format."
+# define FAILED_OPEN_FILE		"Failed to open file."
+# define FAILED_READ_FILE		"Failed to read file."
+# define FAILED_CLOSE_FILE		"Failed to close file."
+# define FAILED_ALLOC_MEM		"Failed to allocate memory."
 
-# define INVALID_FILE			"invalid file format.\n"
-# define INVALID_CONTENT_FMT	"invalid content format.\n"
-# define FAILED_OPEN_FILE		"failed to open file.\n"
-# define FAILED_ALLOC_MEM		"failed to allocate memory.\n"
-# define INVALID_NUM_ARG		"invalid number of argument.\n"
-# define INVALID_NUM_FMT		"invalid number format.\n"
-# define FAILED_PARSE_VEC		"parse vector failed.\n"
-# define FAILED_NORM_VEC		"Normalized vector failed.\n"
-# define INCORRECT_VIEWPORT		"incorrect viewport size.\n"
-
-# define WINDOW_WIDTH		1600
-# define WINDOW_HEIGHT		900
+# define WINDOW_WIDTH		640
+# define WINDOW_HEIGHT		360
 # define HORIZONTAL_UNIT	1
 # define VERTICAL_UNIT		1
 

--- a/include/reader_private.h
+++ b/include/reader_private.h
@@ -13,17 +13,20 @@
 #ifndef READER_PRIVATE_H
 # define READER_PRIVATE_H
 
-# include <fcntl.h>
-# include <unistd.h>
 # include "reader.h"
 # include "utils.h"
+# include "ft_printf.h"
+# include "get_next_line.h"
+# include <errno.h>
+# include <fcntl.h>
+# include <unistd.h>
 
 bool	is_valid_filename(char *filename);
-bool	is_valid_number(char *str);
+bool	is_valid_float(char *str);
 bool	is_valid_vector(char *str);
 
-bool	parse_environment(t_scene *scene, char **tokens);
-bool	parse_object(t_scene *scene, char **tokens);
+bool	parse_environment(t_scene *scene, char *id);
+bool	parse_object(t_scene *scene, char *id);
 bool	parse_vector(t_vec3 *v, char *str);
 bool	parse_unit_vector(t_vec3 *v, char *str);
 bool	parse_color_vector(t_vec3 *v, char *str);

--- a/include/render.h
+++ b/include/render.h
@@ -21,5 +21,9 @@
 int		display(t_minirt *minirt);
 int		render(t_minirt *minirt);
 t_vec3	compute_color(t_scene *scene, t_hit_record *rec);
+bool	iter_pixels(void *param,
+			t_pixel_grid *pixel,
+			t_ray *ray_pool,
+			bool (*f)(void *, t_ray *));
 
 #endif

--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -63,6 +63,7 @@ DIR		:=	get_next_line/
 SRC		+=	$(addprefix $(DIR), \
 			get_next_line.c \
 			get_next_line_utils.c \
+			free_get_next_line.c \
 )
 
 # Lists:

--- a/libraries/libft/inc/get_next_line.h
+++ b/libraries/libft/inc/get_next_line.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/31 12:28:58 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/29 05:44:26 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/27 09:09:28 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,9 @@ size_t	count_result_size(t_buf *cur);
 ssize_t	find_endofline(t_buf *cur);
 void	free_list(t_buf **head);
 int		initial_check(int fd, t_buf **head);
+
+\
+/* free_get_next_line.c */
+void	free_get_next_line(void);
 
 #endif

--- a/libraries/libft/src/get_next_line/free_get_next_line.c
+++ b/libraries/libft/src/get_next_line/free_get_next_line.c
@@ -1,25 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   utils.h                                            :+:      :+:    :+:   */
+/*   free_get_next_line.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/05/28 14:46:03 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/18 16:56:59 by lyeh             ###   ########.fr       */
+/*   Created: 2024/06/27 09:07:32 by ldulling          #+#    #+#             */
+/*   Updated: 2024/06/27 09:08:22 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef UTILS_H
-# define UTILS_H
+#include "get_next_line.h"
 
-# include "ft_printf.h"
-# include <stdlib.h>
-# include <stdio.h>
-# include <unistd.h>
-
-void	free_array(char **array);
-int		get_array_size(char **array);
-void	print_error(char *reason);
-
-#endif
+void	free_get_next_line(void)
+{
+	(void) get_next_line(-1);
+}

--- a/notes.md
+++ b/notes.md
@@ -8,3 +8,6 @@ object change:
 
 light change:
 										cache_color update
+
+# Parsing
+Need to allow tab bc in subject examples it also uses tab

--- a/source/main.c
+++ b/source/main.c
@@ -14,6 +14,7 @@
 #include "minirt.h"
 #include "mlx_utils.h"
 #include "render.h"
+#include "ft_printf.h"
 
 int	main(int argc, char *argv[])
 {
@@ -21,7 +22,7 @@ int	main(int argc, char *argv[])
 
 	if (argc != 2)
 	{
-		printf("main: %s", INVALID_NUM_ARG);
+		ft_dprintf(STDERR_FILENO, "Error: %s", INVALID_NUM_ARG);
 		return (ERR_ARGC);
 	}
 	if (!init_minirt(&minirt, argv[1]))

--- a/source/minirt.c
+++ b/source/minirt.c
@@ -95,7 +95,7 @@ bool	init_ray_pool(t_ray **ray_pool, t_camera *camera)
 	*ray_pool = (t_ray *)malloc(
 			sizeof(t_ray) * camera->pixel.col_size * camera->pixel.row_size);
 	if (!*ray_pool)
-		return (false);
+		return (print_error(FAILED_ALLOC_MEM), false);
 	i = 0;
 	while (i < camera->pixel.row_size)
 	{

--- a/source/minirt.c
+++ b/source/minirt.c
@@ -12,6 +12,7 @@
 
 #include "minirt.h"
 #include "debug.h"
+#include "render.h"
 
 static bool		init_ray_pool(t_ray **ray_pool, t_camera *camera);
 static t_ray	create_ray_from_pixel_grid(t_camera *camera, int row, int col);
@@ -34,20 +35,33 @@ bool	init_minirt(t_minirt *minirt, char *filename)
 	return (true);
 }
 
-void	free_minirt(t_minirt *minirt)
+void	free_ray_pool(t_ray **ray_pool, t_pixel_grid *pixel)
 {
 	int	i;
-	int	ray_amount;
+	int	j;
 
-	ray_amount = minirt->scene->camera.pixel.row_size * \
-		minirt->scene->camera.pixel.col_size;
+	if (!pixel)
+		return ;
 	i = 0;
-	while (i < ray_amount)
+	while (i < pixel->row_size)
 	{
-		ft_lstclear(&minirt->ray_pool[i].hit_record_list, free);
+		j = 0;
+		while (j < pixel->col_size)
+		{
+			ft_lstclear(
+				&(*ray_pool)[i * pixel->col_size + j].hit_record_list, free);
+			j++;
+		}
 		i++;
 	}
-	ft_free_and_null((void **)&minirt->ray_pool);
+	ft_free_and_null((void **)ray_pool);
+}
+
+void	free_minirt(t_minirt *minirt)
+{
+	if (!minirt->scene)
+		return ;
+	free_ray_pool(&minirt->ray_pool, &minirt->scene->camera.pixel);
 	free_scene(&minirt->scene);
 }
 

--- a/source/minirt.c
+++ b/source/minirt.c
@@ -19,8 +19,9 @@ static t_ray	create_ray_from_pixel_grid(t_camera *camera, int row, int col);
 
 bool	init_minirt(t_minirt *minirt, char *filename)
 {
+	ft_bzero(minirt, sizeof(t_minirt));
 	minirt->scene = read_scene(filename);
-	if (!minirt->scene)	//TODO: Check clean exit here
+	if (!minirt->scene)
 		return (false);
 	printf("haha 0\n");
 	init_camera(&minirt->scene->camera);

--- a/source/mlx/events.c
+++ b/source/mlx/events.c
@@ -4,6 +4,10 @@
 
 int	clean_and_exit(t_minirt *minirt)
 {
+	mlx_destroy_window(minirt->mlx.mlx_ptr, minirt->mlx.win_ptr);
+	mlx_destroy_image(minirt->mlx.mlx_ptr, minirt->mlx.img.img_ptr);
+	mlx_destroy_display(minirt->mlx.mlx_ptr);
+	free(minirt->mlx.mlx_ptr);
 	free_minirt(minirt);
 	exit (0);
 }

--- a/source/reader/reader.c
+++ b/source/reader/reader.c
@@ -12,8 +12,9 @@
 
 #include "reader_private.h"
 
-static bool		parse_line(t_scene *scene, char *line);
 static t_scene	*parse_scene(int fd);
+static bool		parse_line(t_scene *scene, char *line);
+static bool		is_only_whitespace(char *line);
 
 t_scene	*read_scene(char *filename)
 {
@@ -83,10 +84,21 @@ bool	parse_line(t_scene *scene, char *line)
 		if (!parse_object(scene, id))
 			return (false);
 	}
-	else
+	else if (!is_only_whitespace(line))
 	{
 		print_error(INVALID_IDENTIFIER);
 		return (false);
+	}
+	return (true);
+}
+
+bool	is_only_whitespace(char *line)
+{
+	while (*line)
+	{
+		if (!ft_isspace(*line))
+			return (false);
+		line++;
 	}
 	return (true);
 }

--- a/source/reader/reader_check.c
+++ b/source/reader/reader_check.c
@@ -24,38 +24,52 @@ bool	is_valid_filename(char *filename)
 	return (true);
 }
 
-bool	is_valid_number(char *str)
+bool	is_valid_float(char *str)
 {
-	int	i;
+	bool	saw_digit;
+	int		i;
 
+	saw_digit = false;
 	i = 0;
-	while (str[i] && str[i] != '\n')
+	if (ft_issign(str[i]))
+		i++;
+	if (!ft_isdigit(str[i]) && str[i] != '.')
+		return (false);
+	while (ft_isdigit(str[i]))
 	{
-		if (!ft_isdigit(str[i]) && \
-			str[i] != '.' && str[i] != '-' && str[i] != '+')
-			return (false);
+		saw_digit = true;
 		i++;
 	}
+	if (str[i] == '.')
+		i++;
+	while (ft_isdigit(str[i]))
+	{
+		saw_digit = true;
+		i++;
+	}
+	if (!saw_digit || (str[i] && str[i] != '\n'))
+		return (false);
 	return (true);
 }
 
 bool	is_valid_vector(char *str)
 {
-	int	i;
-	int	comma;
+	char	*element;
+	int		i;
 
-	i = 0;
-	comma = 0;
-	while (str[i] && str[i] != '\n')
-	{
-		if (!ft_isdigit(str[i]) && \
-			str[i] != '.' && str[i] != '-' && str[i] != '+' && str[i] != ',')
-			return (false);
-		if (str[i] == ',')
-			comma++;
-		i++;
-	}
-	if (comma != 2)
+	if (str[ft_strlen(str) - 1] == ',')
 		return (false);
-	return (true);
+	i = 0;
+	element = ft_strtok(str, ",");
+	while (element)
+	{
+		if (!is_valid_float(element))
+			return (false);
+		i++;
+		element = ft_strtok(NULL, ",");
+		if (!element)
+			break ;
+		element[-1] = ',';
+	}
+	return (i == 3);
 }

--- a/source/reader/reader_environment.c
+++ b/source/reader/reader_environment.c
@@ -12,68 +12,87 @@
 
 #include "reader_private.h"
 
-static bool	parse_ambient(t_scene *scene, char **tokens);
-static bool	parse_camera(t_scene *scene, char **tokens);
-static bool	parse_light(t_scene *scene, char **tokens);
+static bool	parse_ambient(t_scene *scene);
+static bool	parse_camera(t_scene *scene);
+static bool	parse_light(t_scene *scene);
 
-bool	parse_environment(t_scene *scene, char **tokens)
+bool	parse_environment(t_scene *scene, char *id)
 {
-	if (ft_strcmp(tokens[0], "A") == 0)
+	if (ft_strcmp(id, "A") == 0)
 	{
-		if (!parse_ambient(scene, tokens + 1))
-			return (false);
+		if (!parse_ambient(scene))
+			return (print_error(INVALID_AMB_FMT), false);
 	}
-	else if (ft_strcmp(tokens[0], "C") == 0)
+	else if (ft_strcmp(id, "C") == 0)
 	{
-		if (!parse_camera(scene, tokens + 1))
-			return (false);
+		if (!parse_camera(scene))
+			return (print_error(INVALID_CAM_FMT), false);
 	}
-	else if (ft_strcmp(tokens[0], "L") == 0)
+	else if (ft_strcmp(id, "L") == 0)
 	{
-		if (!parse_light(scene, tokens + 1))
-			return (false);
+		if (!parse_light(scene))
+			return (print_error(INVALID_LIG_FMT), false);
 	}
 	return (true);
 }
 
-bool	parse_ambient(t_scene *scene, char **tokens)
+bool	parse_ambient(t_scene *scene)
 {
-	if (get_array_size(tokens) != 2)
-		return (printf("parse_ambient: %s", INVALID_NUM_ARG), false);
-	if (!is_valid_number(tokens[0]) || !is_valid_vector(tokens[1]))
-		return (printf("parse_ambient: %s", INVALID_CONTENT_FMT), false);
-	scene->amblight.ratio = ft_atof(tokens[0]);
-	if (!parse_color_vector(&scene->amblight.color, tokens[1]))
-		return (printf("parse_ambient: %s", FAILED_PARSE_VEC), false);
+	char	*ratio;
+	char	*color;
+
+	ratio = ft_strtok(NULL, WHITESPACE);
+	color = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_float(ratio) || !is_valid_vector(color))
+		return (false);
+	scene->amblight.ratio = ft_atof(ratio);
+	if (!parse_color_vector(&scene->amblight.color, color))
+		return (false);
 	return (true);
 }
 
-bool	parse_camera(t_scene *scene, char **tokens)
+bool	parse_camera(t_scene *scene)
 {
-	if (get_array_size(tokens) != 3)
-		return (printf("parse_camera: %s", INVALID_NUM_ARG), false);
-	if (!is_valid_vector(tokens[0]) || \
-		!is_valid_vector(tokens[1]) || !is_valid_number(tokens[2]))
-		return (printf("parse_camera: %s", INVALID_CONTENT_FMT), false);
-	if (!parse_vector(&scene->camera.org_position, tokens[0]))
-		return (printf("parse_camera: %s", FAILED_PARSE_VEC), false);
-	if (!parse_unit_vector(&scene->camera.org_norm, tokens[1]))
-		return (printf("parse_camera: %s", FAILED_PARSE_VEC), false);
-	scene->camera.fov = ft_atof(tokens[2]);
+	char	*position;
+	char	*norm;
+	char	*fov;
+
+	position = ft_strtok(NULL, WHITESPACE);
+	norm = ft_strtok(NULL, WHITESPACE);
+	fov = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_vector(position) || \
+		!is_valid_vector(norm) || !is_valid_float(fov))
+		return (false);
+	if (!parse_vector(&scene->camera.org_position, position))
+		return (false);
+	if (!parse_unit_vector(&scene->camera.org_norm, norm))
+		return (false);
+	scene->camera.fov = ft_atof(fov);
 	return (true);
 }
 
-bool	parse_light(t_scene *scene, char **tokens)
+bool	parse_light(t_scene *scene)
 {
-	if (get_array_size(tokens) != 3)
-		return (printf("parse_light: %s", INVALID_NUM_ARG), false);
-	if (!is_valid_vector(tokens[0]) || \
-		!is_valid_number(tokens[1]) || !is_valid_vector(tokens[2]))
-		return (printf("parse_light: %s", INVALID_CONTENT_FMT), false);
-	if (!parse_vector(&scene->light.org_position, tokens[0]))
-		return (printf("parse_light: %s", FAILED_PARSE_VEC), false);
-	scene->light.ratio = ft_atof(tokens[1]);
-	if (!parse_color_vector(&scene->light.color, tokens[2]))
-		return (printf("parse_light: %s", FAILED_PARSE_VEC), false);
+	char	*position;
+	char	*ratio;
+	char	*color;
+
+	position = ft_strtok(NULL, WHITESPACE);
+	ratio = ft_strtok(NULL, WHITESPACE);
+	color = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_vector(position) || \
+		!is_valid_float(ratio) || !is_valid_vector(color))
+		return (false);
+	if (!parse_vector(&scene->light.org_position, position))
+		return (false);
+	scene->light.ratio = ft_atof(ratio);
+	if (!parse_color_vector(&scene->light.color, color))
+		return (false);
 	return (true);
 }

--- a/source/reader/reader_free.c
+++ b/source/reader/reader_free.c
@@ -14,6 +14,8 @@
 
 void	free_scene(t_scene **scene)
 {
+	if (!*scene)
+		return ;
 	ft_lstclear(&(*scene)->objects, free);
 	ft_free_and_null((void **)scene);
 }

--- a/source/reader/reader_object.c
+++ b/source/reader/reader_object.c
@@ -12,103 +12,106 @@
 
 #include "reader_private.h"
 
-static bool	parse_sphere(t_scene *scene, char **tokens);
-static bool	parse_plane(t_scene *scene, char **tokens);
-static bool	parse_cylinder(t_scene *scene, char **tokens);
+static bool	parse_sphere(t_obj *object);
+static bool	parse_plane(t_obj *object);
+static bool	parse_cylinder(t_obj *object);
 
-bool	parse_object(t_scene *scene, char **tokens)
-{
-	if (ft_strcmp(tokens[0], "sp") == 0)
-	{
-		if (!parse_sphere(scene, tokens + 1))
-			return (false);
-	}
-	else if (ft_strcmp(tokens[0], "pl") == 0)
-	{
-		if (!parse_plane(scene, tokens + 1))
-			return (false);
-	}
-	else if (ft_strcmp(tokens[0], "cy") == 0)
-	{
-		if (!parse_cylinder(scene, tokens + 1))
-			return (false);
-	}
-	return (true);
-}
-
-bool	parse_sphere(t_scene *scene, char **tokens)
+bool	parse_object(t_scene *scene, char *id)
 {
 	t_obj	*object;
 
-	if (get_array_size(tokens) != SPHERE_ARG_NUM)
-		return (false);
-	if (!is_valid_vector(tokens[0]) || \
-		!is_valid_number(tokens[1]) || !is_valid_vector(tokens[2]))
-		return (printf("parse_sphere: %s", INVALID_CONTENT_FMT), false);
 	object = (t_obj *)ft_calloc(1, sizeof(t_obj));
 	if (!object)
+		return (print_error(FAILED_ALLOC_MEM), false);
+	if (ft_strcmp(id, "sp") == 0)
+	{
+		if (!parse_sphere(object))
+			return (print_error(INVALID_SPH_FMT), free(object), false);
+	}
+	else if (ft_strcmp(id, "pl") == 0)
+	{
+		if (!parse_plane(object))
+			return (print_error(INVALID_PLA_FMT), free(object), false);
+	}
+	else if (ft_strcmp(id, "cy") == 0)
+	{
+		if (!parse_cylinder(object))
+			return (print_error(INVALID_CYL_FMT), free(object), false);
+	}
+	if (!ft_lstnew_back(&scene->objects, object))
+		return (print_error(FAILED_ALLOC_MEM), free(object), false);
+	return (true);
+}
+
+bool	parse_sphere(t_obj *object)
+{
+	char	*position;
+	char	*diameter;
+	char	*color;
+
+	position = ft_strtok(NULL, WHITESPACE);
+	diameter = ft_strtok(NULL, WHITESPACE);
+	color = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_vector(position) || \
+		!is_valid_float(diameter) || !is_valid_vector(color))
 		return (false);
 	object->type = SPHERE;
-	object->d_param1 = ft_atof(tokens[1]);
-	if (!parse_vector(&object->org_position, tokens[0]) || \
-		!parse_color_vector(&object->color, tokens[2]))
-		return (printf("parse_sphere: %s",
-				FAILED_PARSE_VEC), free(object), false);
-	if (!ft_lstnew_back(&scene->objects, object))
-		return (printf("parse_sphere: %s", FAILED_ALLOC_MEM),
-			free(object), false);
+	object->d_param1 = ft_atof(diameter);
+	if (!parse_vector(&object->org_position, position) || \
+		!parse_color_vector(&object->color, color))
+		return (false);
 	return (true);
 }
 
-bool	parse_plane(t_scene *scene, char **tokens)
+bool	parse_plane(t_obj *object)
 {
-	t_obj	*object;
+	char	*position;
+	char	*norm;
+	char	*color;
 
-	if (get_array_size(tokens) != PLANE_ARG_NUM)
-		return (printf("parse_plane: %s", INVALID_NUM_ARG), false);
-	if (!is_valid_vector(tokens[0]) || \
-		!is_valid_vector(tokens[1]) || !is_valid_vector(tokens[2]))
-		return (printf("parse_plane: %s", INVALID_CONTENT_FMT), false);
-	object = (t_obj *)ft_calloc(1, sizeof(t_obj));
-	if (!object)
-		return (printf("parse_plane: %s", FAILED_ALLOC_MEM), false);
+	position = ft_strtok(NULL, WHITESPACE);
+	norm = ft_strtok(NULL, WHITESPACE);
+	color = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_vector(position) || \
+		!is_valid_vector(norm) || !is_valid_vector(color))
+		return (false);
 	object->type = PLANE;
-	if (!parse_vector(&object->org_position, tokens[0]) || \
-		!parse_unit_vector(&object->org_norm, tokens[1]) || \
-		!parse_color_vector(&object->color, tokens[2]))
-		return (printf("parse_plane: %s", FAILED_PARSE_VEC),
-			free(object), false);
-	if (!ft_lstnew_back(&scene->objects, object))
-		return (printf("parse_plane: %s", FAILED_ALLOC_MEM),
-			free(object), false);
+	if (!parse_vector(&object->org_position, position) || \
+		!parse_unit_vector(&object->org_norm, norm) || \
+		!parse_color_vector(&object->color, color))
+		return (false);
 	return (true);
 }
 
-bool	parse_cylinder(t_scene *scene, char **tokens)
+bool	parse_cylinder(t_obj *object)
 {
-	t_obj	*object;
+	char	*position;
+	char	*norm;
+	char	*diameter;
+	char	*height;
+	char	*color;
 
-	if (get_array_size(tokens) != CYLINDER_ARG_NUM)
-		return (printf("parse_cylinder: %s", INVALID_NUM_ARG), false);
-	if (!is_valid_vector(tokens[0]) || !is_valid_vector(tokens[1]) || \
-		!is_valid_number(tokens[2]) || !is_valid_number(tokens[3]) || \
-		!is_valid_vector(tokens[4]))
-		return (printf("parse_cylinder: %s", INVALID_CONTENT_FMT), false);
-	object = (t_obj *)ft_calloc(1, sizeof(t_obj));
-	if (!object)
-		return (printf("parse_cylinder: %s", FAILED_ALLOC_MEM), false);
+	position = ft_strtok(NULL, WHITESPACE);
+	norm = ft_strtok(NULL, WHITESPACE);
+	diameter = ft_strtok(NULL, WHITESPACE);
+	height = ft_strtok(NULL, WHITESPACE);
+	color = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
+		return (false);
+	if (!is_valid_vector(position) || !is_valid_vector(norm) || \
+		!is_valid_float(diameter) || !is_valid_float(height) || \
+		!is_valid_vector(color))
+		return (false);
 	object->type = CYLINDER;
-	object->d_param1 = ft_atof(tokens[2]);
-	object->d_param2 = ft_atof(tokens[3]);
-	object->translation = vector(0.0, 0.0, 0.0);
-	object->rotation = vector(0.0, 0.0, 0.0);
-	if (!parse_vector(&object->org_position, tokens[0]) || \
-		!parse_unit_vector(&object->org_norm, tokens[1]) || \
-		!parse_color_vector(&object->color, tokens[4]))
-		return (printf("parse_cylinder: %s", FAILED_PARSE_VEC),
-			free(object), false);
-	if (!ft_lstnew_back(&scene->objects, object))
-		return (printf("parse_cylinder: %s", FAILED_ALLOC_MEM),
-			free(object), false);
+	object->d_param1 = ft_atof(diameter);
+	object->d_param2 = ft_atof(height);
+	if (!parse_vector(&object->org_position, position) || \
+		!parse_unit_vector(&object->org_norm, norm) || \
+		!parse_color_vector(&object->color, color))
+		return (false);
 	return (true);
 }

--- a/source/reader/reader_utils.c
+++ b/source/reader/reader_utils.c
@@ -14,15 +14,19 @@
 
 bool	parse_vector(t_vec3 *v, char *str)
 {
-	char	**tokens;
+	char	*x;
+	char	*y;
+	char	*z;
 
 	if (v == NULL || str == NULL)
 		return (false);
-	tokens = ft_split(str, ',');
-	if (!tokens || get_array_size(tokens) != 3)
+	x = ft_strtok(str, ",");
+	y = ft_strtok(NULL, ",");
+	z = ft_strtok(NULL, WHITESPACE);
+	if (ft_strtok(NULL, WHITESPACE) != NULL)
 		return (false);
-	*v = vector(ft_atof(tokens[0]), ft_atof(tokens[1]), ft_atof(tokens[2]));
-	return (free_array(tokens), true);
+	*v = vector(ft_atof(x), ft_atof(y), ft_atof(z));
+	return (true);
 }
 
 bool	parse_unit_vector(t_vec3 *v, char *str)
@@ -31,10 +35,10 @@ bool	parse_unit_vector(t_vec3 *v, char *str)
 
 	if (!parse_vector(v, str))
 		return (false);
+	if (vec3.ops->magnitude(*v) == 0)
+		return (false);
 	if (vec3.ops->magnitude(*v) == 1)
 		return (true);
-	if (vec3.ops->magnitude(*v) == 0)
-		return (error_message(FAILED_NORM_VEC), false);
 	*v = vec3.ops->normalize(*v);
 	return (true);
 }

--- a/source/render/render.c
+++ b/source/render/render.c
@@ -13,10 +13,6 @@
 #include "render_private.h"
 #include "transform.h"
 
-static bool		iter_pixels(void *param,
-					t_pixel_grid *pixel,
-					t_ray *ray_pool,
-					bool (*f)(void *, t_ray *));
 static bool		render_pixel(void *param, t_ray *ray_pool);
 static t_vec3	clamp_color(t_vec3 color);
 

--- a/source/utils/error_message.c
+++ b/source/utils/error_message.c
@@ -12,9 +12,8 @@
 
 #include "utils.h"
 
-void	error_message(char *reason)
+void	print_error(char *reason)
 {
-	printf("Error\n");
-	printf("%s\n", reason);
-	exit(EXIT_FAILURE);
+	ft_dprintf(STDERR_FILENO, "Error\n");
+	ft_dprintf(STDERR_FILENO, "%s\n", reason);
 }


### PR DESCRIPTION
- Protect vector and float parsing from invalid formats.
- Fix potential memory leaks by simplifying parsing with `ft_strtok()` instead of `ft_split()`.
- Don't just exit in error message print function.
- Protect against get_next_line() failure.
- Free get_next_line() buffer.
- Destroy and free MLX pointers.
- Correct error messages according to subject.
- Allow all whitespace characters in config files.
- Fix norminette issues in reader by simplifying functions.
- Fix segfault when freeing
- Allow empty and whitespace lines in config files
- Fix segfault with invalid filename
- Print error msg if malloc fails in init