### PR TITLE
[FIX] Free MLX allocations in all cases and fix segfaults caused by MLX

### DIFF
--- a/include/mlx_utils.h
+++ b/include/mlx_utils.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/29 01:02:48 by ldulling          #+#    #+#             */
-/*   Updated: 2024/06/29 15:39:49 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/29 23:09:49 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,9 +18,8 @@
 # include "transform.h"
 
 bool	init_mlx(t_mlx *mlx);
-int		clean_and_exit(t_minirt *minirt);
+void	free_mlx(t_mlx *mlx);
 void	img_pixel_put(t_img *img, int x, int y, int color);
-
 void	setup_event_hooks(t_minirt *minirt);
 
 #endif

--- a/source/minirt.c
+++ b/source/minirt.c
@@ -6,13 +6,14 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/30 19:36:14 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/29 00:54:16 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/29 23:08:24 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minirt.h"
 #include "debug.h"
 #include "render.h"
+#include "mlx_utils.h"
 
 static bool		init_ray_pool(t_ray **ray_pool, t_camera *camera);
 static t_ray	create_ray_from_pixel_grid(t_camera *camera, int row, int col);
@@ -59,10 +60,12 @@ void	free_ray_pool(t_ray **ray_pool, t_pixel_grid *pixel)
 
 void	free_minirt(t_minirt *minirt)
 {
-	if (!minirt->scene)
-		return ;
-	free_ray_pool(&minirt->ray_pool, &minirt->scene->camera.pixel);
-	free_scene(&minirt->scene);
+	free_mlx(&minirt->mlx);
+	if (minirt->scene)
+	{
+		free_ray_pool(&minirt->ray_pool, &minirt->scene->camera.pixel);
+		free_scene(&minirt->scene);
+	}
 }
 
 void	reset_ray_pool(t_ray *ray_pool, t_camera *camera)

--- a/source/mlx/mlx_event.c
+++ b/source/mlx/mlx_event.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/28 21:00:37 by ldulling          #+#    #+#             */
-/*   Updated: 2024/06/29 20:06:39 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/29 23:10:05 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@ static int	handle_keypress_event(int key, t_minirt *minirt);
 static int	handle_keyrelease_event(int key, t_minirt *minirt);
 static int	handle_buttonpress_event(
 				int button, int x, int y, t_minirt *minirt);
+static int	clean_and_exit(t_minirt *minirt);
 
 void	setup_event_hooks(t_minirt *minirt)
 {
@@ -58,4 +59,10 @@ int	handle_buttonpress_event(int button, int x, int y, t_minirt *minirt)
 	(void)y;
 	interact_object(button, minirt);
 	return (0);
+}
+
+int	clean_and_exit(t_minirt *minirt)
+{
+	free_minirt(minirt);
+	exit (0);
 }

--- a/source/mlx/mlx_init.c
+++ b/source/mlx/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/29 15:40:04 by ldulling          #+#    #+#             */
-/*   Updated: 2024/06/29 15:40:15 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/29 23:09:21 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,12 +31,14 @@ bool	init_mlx(t_mlx *mlx)
 	return (true);
 }
 
-int	clean_and_exit(t_minirt *minirt)
+void	free_mlx(t_mlx *mlx)
 {
-	mlx_destroy_window(minirt->mlx.mlx_ptr, minirt->mlx.win_ptr);
-	mlx_destroy_image(minirt->mlx.mlx_ptr, minirt->mlx.img.img_ptr);
-	mlx_destroy_display(minirt->mlx.mlx_ptr);
-	free(minirt->mlx.mlx_ptr);
-	free_minirt(minirt);
-	exit (0);
+	if (mlx->win_ptr)
+		mlx_destroy_window(mlx->mlx_ptr, mlx->win_ptr);
+	if (mlx->img.img_ptr)
+		mlx_destroy_image(mlx->mlx_ptr, mlx->img.img_ptr);
+	if (mlx->mlx_ptr)
+		mlx_destroy_display(mlx->mlx_ptr);
+	free(mlx->mlx_ptr);
+	ft_bzero(mlx, sizeof(t_mlx));
 }


### PR DESCRIPTION
- [x] First merge #29 
---
Segfaults were caused by the mlx destroy functions when anything in `init_mlx()` failed.