### PR TITLE
[BUILD] Fix `make val`, `make valfd` and `make run` Makefile goals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ BUILD_DIR		:=	build
 OBJ_DIR			:=	$(BUILD_DIR)/_obj
 DEP_DIR			:=	$(BUILD_DIR)/_dep
 LIB_DIR			:=	libraries
+ASSET_DIR		:=	assets
 
 
 #	Dependencies
@@ -132,17 +133,20 @@ test			:
 							|| (echo $(MSG_FAILURE) && exit 42))
 					"./$(NAME_TEST)"
 
-val				:	all
-					$(VALGRIND) $(VALGRINDFLAGS) "./$(NAME)"
+val				:	fast
+					$(VALGRIND) $(VALGRINDFLAGS) \
+					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
 
-valfd			:	all
+valfd			:	fast
 ifneq ($(TERMINAL),)
 					$(TERMINAL) $(TERMINALFLAGS) \
 					"bash -c 'trap \"\" SIGINT ; \
-					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) ./$(NAME) ; \
+					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) \
+					./$(NAME) $(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1); \
 					exec bash'"
 else
-					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) "./$(NAME)"
+					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) \
+					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ LIBFLAGS		:=	$(addprefix -L,$(LIBS)) \
 LIBFLAGS_TEST	:=	$(addprefix -l,$(LIBS_EXT_TEST))
 MAKEFLAGS		:=	-j -s
 
+ARGS				?=	$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)
+
 
 #	Valgrind
 
@@ -124,7 +126,7 @@ fast			:	re
 					$(MAKE) clean
 
 run				:	all
-					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
+					"./$(NAME)" $(ARGS)
 
 test			:
 					($(MAKE) --question build_test && echo $(MSG_NO_CHNG)) \
@@ -136,22 +138,19 @@ test			:
 san				:	CFLAGS := $(CFLAGS_STD) $(CFLAGS_SAN)
 san				:	re
 					$(MAKE) clean
-					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
+					"./$(NAME)" $(ARGS)
 
 val				:	all
-					$(VALGRIND) $(VALGRINDFLAGS) \
-					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
+					$(VALGRIND) $(VALGRINDFLAGS) "./$(NAME)" $(ARGS)
 
 valfd			:	all
 ifneq ($(TERMINAL),)
 					$(TERMINAL) $(TERMINALFLAGS) \
 					"bash -c 'trap \"\" SIGINT ; \
-					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) \
-					./$(NAME) $(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1); \
+					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) ./$(NAME) $(ARGS) ; \
 					exec bash'"
 else
-					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) \
-					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
+					$(VALGRIND) $(VALGRINDFLAGS) $(VALGRINDFDFLAGS) "./$(NAME)" $(ARGS)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ fast			:	re
 					$(MAKE) clean
 
 run				:	all
-					"./$(NAME)"
+					"./$(NAME)" "$(ASSET_DIR)/$(shell ls -1 $(ASSET_DIR) | head -n 1)"
 
 test			:
 					($(MAKE) --question build_test && echo $(MSG_NO_CHNG)) \


### PR DESCRIPTION
- Fix conflict with fsanitize and valgrind.
- Add `make san` goal and compile by default without sanitizer now.
- Give arguments to make like `make run ARGS=...`
  - If no `ARGS` defined, default to the alphabetically first config file in the assets/ folder.