### PR TITLE
[FIX] Fix division by zero

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -23,8 +23,9 @@ Need to allow tab bc in subject examples it also uses tab
 # Todo
 - [ ] Rename objects to object_list.
 - [X] We don't do anything with ratio/brightness atm.
-- [ ] Reset zoom.
+- [X] Reset zoom.
 - [X] Check if max values of subject should be checked in parsing.
+- [X] Rename environment to scene.
 
 # MLX functions
 mlx_get_screen_size()

--- a/source/transform/transform.c
+++ b/source/transform/transform.c
@@ -43,7 +43,8 @@ void	transform_objects(t_list_d *object_list)
 	{
 		object = object_list->content;
 		object->position = translate(object->org_position, object->translation);
-		object->norm = rotate(object->org_norm, object->rotation);
+		if (object->type != SPHERE)
+			object->norm = rotate(object->org_norm, object->rotation);
 		object_list = object_list->next;
 	}
 }


### PR DESCRIPTION
Since there is no norm vector specified for spheres in the config files, the norm vector will be (0, 0, 0). If that vector gets normalized when rotating, the magnitude of that vector will be zero.